### PR TITLE
Supported jrpc methods

### DIFF
--- a/src/implementation.md
+++ b/src/implementation.md
@@ -107,6 +107,17 @@ To support the light client functionality we will implement the support of the f
 - /paritytech/grandpa/1
 - /dot/transactions/1
 
+## @substrate/connect Extension Protocol
+
+The following methods will be implemented:
+- ToApplicationError
+- ToApplicationChainReady
+- ToApplicationRpc
+- ToExtensionAddChain
+- ToExtensionAddWellKnownChain
+- ToExtensionRpc
+- ToExtensionRemoveChain
+
 
 ## JSON-RPC methods
 

--- a/src/implementation.md
+++ b/src/implementation.md
@@ -121,7 +121,23 @@ The following methods will be implemented:
 
 ## JSON-RPC methods
 
-The following methods will be implemented: `rpc_methods`, `chainHead_unstable_follow`, `chainHead_unstable_unfollow`, `chainHead_unstable_unpin`, `chainHead_unstable_storage`, `chainHead_unstable_call` and `chainHead_unstable_stopCall`. All of `chainHead` methods allow tracking of the chain and their storage. The most important ones that will be implemented at the first stage are:
+The following methods will be implemented:
+- `rpc_methods`
+- `chainHead_unstable_follow`
+- `chainHead_unstable_unfollow`
+- `chainHead_unstable_unpin`
+- `chainHead_unstable_storage`
+- `chainHead_unstable_call`
+- `chainHead_unstable_stopCall`
+- `chainHead_unstable_body`
+- `chainHead_unstable_genesisHash`
+- `chainHead_unstable_header`
+- `chainHead_unstable_stopBody`
+- `chainHead_unstable_stopStorage`
+- `transaction_unstable_submitAndWatch`
+- `transaction_unstable_unwatch`
+
+All of `chainHead` methods allow tracking of the chain and their storage. The most important ones that will be implemented at the first stage are:
 - `chainHead_unstable_follow` : the first method that should be called by the client. It returns the current list of blocks that are near the head of the chain and generates notifications about new blocks.
 - `chainHead_unstable_unpin` : should be called whenever a `{"event": "finalized"}` notification is received by a subscriber
 - `chainHead_unstable_unfollow` : stops a subscription started with `chainHead_unstable_follow`

--- a/src/implementation.md
+++ b/src/implementation.md
@@ -129,20 +129,15 @@ The following methods will be implemented:
 - `chainHead_unstable_storage`
 - `chainHead_unstable_call`
 - `chainHead_unstable_stopCall`
-- `chainHead_unstable_body`
-- `chainHead_unstable_genesisHash`
-- `chainHead_unstable_header`
-- `chainHead_unstable_stopBody`
-- `chainHead_unstable_stopStorage`
 - `transaction_unstable_submitAndWatch`
 - `transaction_unstable_unwatch`
 
-All of `chainHead` methods allow tracking of the chain and their storage. The most important ones that will be implemented at the first stage are:
+The `chainHead` methods allow tracking of the chain and their storage. The most important ones that will be implemented at the first stage are:
 - `chainHead_unstable_follow` : the first method that should be called by the client. It returns the current list of blocks that are near the head of the chain and generates notifications about new blocks.
 - `chainHead_unstable_unpin` : should be called whenever a `{"event": "finalized"}` notification is received by a subscriber
 - `chainHead_unstable_unfollow` : stops a subscription started with `chainHead_unstable_follow`
 
-The remaining methods will allow the client to get more information about blocks in the chain.
+The `transaction` methods enable transaction execution and tracking.
 
 ## Storage
 

--- a/src/implementation.md
+++ b/src/implementation.md
@@ -132,13 +132,12 @@ The following methods will be implemented:
 - `transaction_unstable_submitAndWatch`
 - `transaction_unstable_unwatch`
 
-The `chainHead` methods allow tracking of the chain and their storage. The most important ones that will be implemented at the first stage are:
+The `chainHead_` methods allow tracking of the chain and their storage. The most important ones that will be implemented at the first stage are:
 - `chainHead_unstable_follow` : the first method that should be called by the client. It returns the current list of blocks that are near the head of the chain and generates notifications about new blocks.
 - `chainHead_unstable_unpin` : should be called whenever a `{"event": "finalized"}` notification is received by a subscriber
 - `chainHead_unstable_unfollow` : stops a subscription started with `chainHead_unstable_follow`
 
-The `transaction` methods enable transaction execution and tracking.
-
+The two `transaction_` methods enable the submission and tracking of transactions via `transaction_unstable_watchEvent`'s.
 ## Storage
 
 We will use a hash map to store the blockchain state.  This is an in-memory serialization/deserialization data structure, consisting of the current peers and block header information for some number of blocks (i.e., a history). This object functions as a *de facto* database.

--- a/src/requirements.md
+++ b/src/requirements.md
@@ -36,7 +36,7 @@ Note: The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “
 - The client MUST be able to subscribe/unsubscribe to/from any polkadot-spec-conformant relay chain (Polkadot, Westend, Kusama)
 - The client MUST be able to subscribe/unsubscribe to/from parachains that do not use custom protocols or cryptography methods other than those that Polkadot, Westend and Kusama use.
 - The client MUST support the following [RPC methods](https://paritytech.github.io/json-rpc-interface-spec/):
-  - `rpc_methods`, `chainHead_unstable_follow`, `chainHead_unstable_unfollow`, `chainHead_unstable_unpin`, `chainHead_unstable_storage`, `chainHead_unstable_call` `chainHead_unstable_stopCall`. `chainHead_unstable_genesisHash`, `chainHead_unstable_header`, `chainHead_unstable_stopBody`, `chainHead_unstable_stopStorage`, `transaction_unstable_submitAndWatch`, and `transaction_unstable_unwatch`
+  - `rpc_methods`, `chainHead_unstable_follow`, `chainHead_unstable_unfollow`, `chainHead_unstable_unpin`, `chainHead_unstable_storage`, `chainHead_unstable_call` `chainHead_unstable_stopCall`. `transaction_unstable_submitAndWatch`, and `transaction_unstable_unwatch`
 - The client MUST support the `@substrate/connect` [connection extension protocol](https://github.com/paritytech/substrate-connect/tree/main/packages/connect-extension-protocol):
   - `ToApplicationError`, `ToApplicationChainReady`, `ToApplicationRpc`, `ToExtensionAddChain`, `ToExtensionAddWellKnownChain`, `ToExtensionRpc`,` ToExtensionRemoveChain`
 

--- a/src/requirements.md
+++ b/src/requirements.md
@@ -35,9 +35,11 @@ Note: The key words “MUST”, “MUST NOT”, “REQUIRED”, “SHALL”, “
 - The client MUST be able to retrieve checkpoint state from a trusted source to speed up initialization.
 - The client MUST be able to subscribe/unsubscribe to/from any polkadot-spec-conformant relay chain (Polkadot, Westend, Kusama)
 - The client MUST be able to subscribe/unsubscribe to/from parachains that do not use custom protocols or cryptography methods other than those that Polkadot, Westend and Kusama use.
-- The client MUST be able to send a new transaction.
-- The client MUST be able subscribe to updates from a new transaction
-- The client MUST support the following minimum subset of [RPC methods](https://paritytech.github.io/json-rpc-interface-spec/):
-  - `rpc_methods`, `chainHead_unstable_follow`, `chainHead_unstable_unfollow`, `chainHead_unstable_unpin`, `chainHead_unstable_storage`, `chainHead_unstable_call` and `chainHead_unstable_stopCall`.
+- The client MUST support the following [RPC methods](https://paritytech.github.io/json-rpc-interface-spec/):
+  - `rpc_methods`, `chainHead_unstable_follow`, `chainHead_unstable_unfollow`, `chainHead_unstable_unpin`, `chainHead_unstable_storage`, `chainHead_unstable_call` `chainHead_unstable_stopCall`. `chainHead_unstable_genesisHash`, `chainHead_unstable_header`, `chainHead_unstable_stopBody`, `chainHead_unstable_stopStorage`, `transaction_unstable_submitAndWatch`, and `transaction_unstable_unwatch`
+- The client MUST support the `@substrate/connect` [connection extension protocol](https://github.com/paritytech/substrate-connect/tree/main/packages/connect-extension-protocol):
+  - `ToApplicationError`, `ToApplicationChainReady`, `ToApplicationRpc`, `ToExtensionAddChain`, `ToExtensionAddWellKnownChain`, `ToExtensionRpc`,` ToExtensionRemoveChain`
+
+
 
 [^1]: This could be discussed in future grant proposals.


### PR DESCRIPTION
Changes made which address the latest feedback from the Polkadot grant committee.
- added two transaction_* JSON-RPC methods
- added `@substrate/connect-extension` protocol.  This consists of 7 calls, `ToApplication*/ToExtension*`.